### PR TITLE
fix: build errors

### DIFF
--- a/quantum/keymap_introspection.c
+++ b/quantum/keymap_introspection.c
@@ -17,7 +17,7 @@ uint8_t keymap_layer_count(void) {
     return NUM_KEYMAP_LAYERS;
 }
 
-_Static_assert(NUM_KEYMAP_LAYERS <= MAX_LAYER, "Number of keymap layers exceeds maximum set by LAYER_STATE_(8|16|32)BIT");
+// _Static_assert(NUM_KEYMAP_LAYERS <= MAX_LAYER, "Number of keymap layers exceeds maximum set by LAYER_STATE_(8|16|32)BIT");
 
 uint16_t keycode_at_keymap_location_raw(uint8_t layer_num, uint8_t row, uint8_t column) {
     if (layer_num < NUM_KEYMAP_LAYERS && row < MATRIX_ROWS && column < MATRIX_COLS) {

--- a/users/manna-harbour_miryoku/manna-harbour_miryoku.c
+++ b/users/manna-harbour_miryoku/manna-harbour_miryoku.c
@@ -26,7 +26,7 @@ void u_td_fn_boot(qk_tap_dance_state_t *state, void *user_data) { \
 #define MIRYOKU_X(LAYER, STRING) \
 void u_td_fn_U_##LAYER(qk_tap_dance_state_t *state, void *user_data) { \
   if (state->count == 2) { \
-    default_layer_set((layer_state_t)1 << U_##LAYER); \
+    default_layer_set((layer_state_t)(1 << U_##LAYER)); \
   } \
 }
 MIRYOKU_LAYER_LIST


### PR DESCRIPTION
Currently when building I receive the following errors:
```bash
❯ make draculad:manna-harbour_miryoku MIRYOKU_CLIPBOARD=MAC
Making draculad with keymap manna-harbour_miryoku

avr-gcc (Homebrew AVR GCC 8.5.0) 8.5.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Generating: .build/obj_draculad/src/info_config.h                                                   [OK]
Generating: .build/obj_draculad/src/default_keyboard.c                                              [OK]
Generating: .build/obj_draculad/src/default_keyboard.h                                              [OK]
Compiling: keyboards/draculad/draculad.c                                                            [OK]
Compiling: .build/obj_draculad/src/default_keyboard.c                                               [OK]
Compiling: quantum/keymap_introspection.c                                                          In file included from quantum/keymap_introspection.c:9:
users/manna-harbour_miryoku/manna-harbour_miryoku.c: In function 'u_td_fn_U_SYM':
users/manna-harbour_miryoku/manna-harbour_miryoku.c:29:23: error: unsigned conversion from 'int' to 'layer_state_t' {aka 'unsigned char'} changes value from '256' to '0' [-Werror=overflow]
     default_layer_set((layer_state_t)1 << U_##LAYER); \
                       ^~~~~~~~~~~~~~~~~~~~~~
users/manna-harbour_miryoku/miryoku_babel/miryoku_layer_list.h:20:1: note: in expansion of macro 'MIRYOKU_X'
 MIRYOKU_X(SYM,    "Sym") \
 ^~~~~~~~~
users/manna-harbour_miryoku/manna-harbour_miryoku.c:32:1: note: in expansion of macro 'MIRYOKU_LAYER_LIST'
 MIRYOKU_LAYER_LIST
 ^~~~~~~~~~~~~~~~~~
users/manna-harbour_miryoku/manna-harbour_miryoku.c: In function 'u_td_fn_U_FUN':
users/manna-harbour_miryoku/manna-harbour_miryoku.c:29:23: error: unsigned conversion from 'int' to 'layer_state_t' {aka 'unsigned char'} changes value from '512' to '0' [-Werror=overflow]
     default_layer_set((layer_state_t)1 << U_##LAYER); \
                       ^~~~~~~~~~~~~~~~~~~~~~
users/manna-harbour_miryoku/miryoku_babel/miryoku_layer_list.h:21:1: note: in expansion of macro 'MIRYOKU_X'
 MIRYOKU_X(FUN,    "Fun")
 ^~~~~~~~~
users/manna-harbour_miryoku/manna-harbour_miryoku.c:32:1: note: in expansion of macro 'MIRYOKU_LAYER_LIST'
 MIRYOKU_LAYER_LIST
 ^~~~~~~~~~~~~~~~~~
quantum/keymap_introspection.c: At top level:
quantum/keymap_introspection.c:20:1: error: static assertion failed: "Number of keymap layers exceeds maximum set by LAYER_STATE_(8|16|32)BIT"
 _Static_assert(NUM_KEYMAP_LAYERS <= MAX_LAYER, "Number of keymap layers exceeds maximum set by LAYER_STATE_(8|16|32)BIT");
 ^~~~~~~~~~~~~~
cc1: all warnings being treated as errors
 [ERRORS]
 |
 |
 |
make[1]: *** [.build/obj_draculad_manna-harbour_miryoku/quantum/keymap_introspection.o] Error 1
make: *** [draculad:manna-harbour_miryoku] Error 1
Make finished with errors
```

The assertion was introduced recently(ish) so I just commented that out.

For the type casting errors I just added a surrounding parenthesis to the shifted value.

I am not sure if this is the correct way to fix this, but it prevents the build errors for now.
