### PR TITLE
Add manna-harbour_miryoku keymap to controllerworks/city42

### DIFF
--- a/keyboards/controllerworks/city42/keymaps/manna-harbour_miryoku/config.h
+++ b/keyboards/controllerworks/city42/keymaps/manna-harbour_miryoku/config.h
@@ -1,0 +1,24 @@
+// Copyright 2023 Manna Harbour
+// https://github.com/manna-harbour/miryoku
+
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#define MATRIX_ROW_PINS { GP12, GP13, GP14, GP15 }
+#define MATRIX_COL_PINS { GP28, GP27, GP26, GP25, GP24, GP23, GP0, GP1, GP2, GP3, GP4, GP5 }
+
+#define XXX KC_NO
+
+#define LAYOUT_miryoku( \
+K00,   K01,   K02,   K03,   K04,          K05,   K06,   K07,   K08,   K09, \
+K10,   K11,   K12,   K13,   K14,          K15,   K16,   K17,   K18,   K19, \
+K20,   K21,   K22,   K23,   K24,          K25,   K26,   K27,   K28,   K29, \
+N30,   N31,   K32,   K33,   K34,          K35,   K36,   K37,   N38,   N39 \
+) \
+LAYOUT_split_3x6_3( \
+XXX,   K00,   K01,   K02,   K03,   K04,          K05,   K06,   K07,   K08,   K09,   XXX, \
+XXX,   K10,   K11,   K12,   K13,   K14,          K15,   K16,   K17,   K18,   K19,   XXX, \
+XXX,   K20,   K21,   K22,   K23,   K24,          K25,   K26,   K27,   K28,   K29,   XXX, \
+XXX,   XXX,   K32,   K33,   K34,   XXX,          XXX,   K35,   K36,   K37,   XXX,   XXX \
+)

--- a/keyboards/controllerworks/city42/keymaps/manna-harbour_miryoku/keymap.c
+++ b/keyboards/controllerworks/city42/keymaps/manna-harbour_miryoku/keymap.c
@@ -1,0 +1,4 @@
+// Copyright 2023 Manna Harbour
+// https://github.com/manna-harbour/miryoku
+
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with this program. If not, see <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
Trying very hard to get the Miryoku working on [ControllerWorks's City42](https://github.com/qmk/qmk_firmware/tree/master/keyboards/controllerworks/city42).

I gave this a good crack, and would appreciate some guidance on where I might have gone wrong. I referenced [this post](https://github.com/manna-harbour/miryoku/discussions/264#discussioncomment-7670489), from Manna Harbour, [from the discussion on the most recent addition of a keyboard I could find](https://github.com/manna-harbour/miryoku/discussions/264).

#### In this PR:

- Updated `config.h` for City42's pin configuration and adapted the `LAYOUT_miryoku` macro for its 3x6+3 layout.

- Copied the empty `keymap.c` as other seem to do? I don't get this part.

#### Issue:

_My current understanding from this error is that no keymap layers are found ... that makes sense given the files is empty ... but then, how are other keyboards achieving build success?_

I'm facing a compilation error related to 'keymaps' and 'MAX_LAYER' not being declared, which seems specific to the Miryoku layout or City42's configuration. Assistance in troubleshooting this issue would be appreciated.

```
❯ qmk compile -kb controllerworks/city42 -km manna-harbour_miryoku
Ψ Compiling keymap with gmake -r -R -f builddefs/build_keyboard.mk -s KEYBOARD=controllerworks/city42 KEYMAP=manna-harbour_miryoku KEYBOARD_FILESAFE=controllerworks_city42 TARGET=controllerworks_city42_manna-harbour_miryoku INTERMEDIATE_OUTPUT=.build/obj_controllerworks_city42_manna-harbour_miryoku VERBOSE=false COLOR=true SILENT=false QMK_BIN="qmk"


arm-none-eabi-gcc (Homebrew ARM GCC 8.5.0_1) 8.5.0
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

Compiling: quantum/keymap_introspection.c                                                          quantum/keymap_introspection.c: In function 'keymap_layer_count_raw':
quantum/keymap_introspection.c:17:49: error: 'keymaps' undeclared (first use in this function)
 #define NUM_KEYMAP_LAYERS_RAW ((uint8_t)(sizeof(keymaps) / ((MATRIX_ROWS) * (MATRIX_COLS) * sizeof(uint16_t))))
                                                 ^~~~~~~
quantum/keymap_introspection.c:20:12: note: in expansion of macro 'NUM_KEYMAP_LAYERS_RAW'
     return NUM_KEYMAP_LAYERS_RAW;
            ^~~~~~~~~~~~~~~~~~~~~
quantum/keymap_introspection.c:17:49: note: each undeclared identifier is reported only once for each function it appears in
 #define NUM_KEYMAP_LAYERS_RAW ((uint8_t)(sizeof(keymaps) / ((MATRIX_ROWS) * (MATRIX_COLS) * sizeof(uint16_t))))
                                                 ^~~~~~~
quantum/keymap_introspection.c:20:12: note: in expansion of macro 'NUM_KEYMAP_LAYERS_RAW'
     return NUM_KEYMAP_LAYERS_RAW;
            ^~~~~~~~~~~~~~~~~~~~~
quantum/keymap_introspection.c: At top level:
quantum/keymap_introspection.c:17:49: error: 'keymaps' undeclared here (not in a function)
 #define NUM_KEYMAP_LAYERS_RAW ((uint8_t)(sizeof(keymaps) / ((MATRIX_ROWS) * (MATRIX_COLS) * sizeof(uint16_t))))
                                                 ^~~~~~~
quantum/keymap_introspection.c:30:16: note: in expansion of macro 'NUM_KEYMAP_LAYERS_RAW'
 _Static_assert(NUM_KEYMAP_LAYERS_RAW <= MAX_LAYER, "Number of keymap layers exceeds maximum set by LAYER_STATE_(8|16|32)BIT");
                ^~~~~~~~~~~~~~~~~~~~~
quantum/keymap_introspection.c:30:41: error: 'MAX_LAYER' undeclared here (not in a function)
 _Static_assert(NUM_KEYMAP_LAYERS_RAW <= MAX_LAYER, "Number of keymap layers exceeds maximum set by LAYER_STATE_(8|16|32)BIT");
                                         ^~~~~~~~~
quantum/keymap_introspection.c:17:31: error: expression in static assertion is not an integer
 #define NUM_KEYMAP_LAYERS_RAW ((uint8_t)(sizeof(keymaps) / ((MATRIX_ROWS) * (MATRIX_COLS) * sizeof(uint16_t))))
                               ^
quantum/keymap_introspection.c:30:16: note: in expansion of macro 'NUM_KEYMAP_LAYERS_RAW'
 _Static_assert(NUM_KEYMAP_LAYERS_RAW <= MAX_LAYER, "Number of keymap layers exceeds maximum set by LAYER_STATE_(8|16|32)BIT");
                ^~~~~~~~~~~~~~~~~~~~~
quantum/keymap_introspection.c: In function 'keycode_at_keymap_location_raw':
quantum/keymap_introspection.c:35:16: error: implicit declaration of function 'pgm_read_word' [-Werror=implicit-function-declaration]
         return pgm_read_word(&keymaps[layer_num][row][column]);
                ^~~~~~~~~~~~~
quantum/keymap_introspection.c:37:12: error: 'KC_TRNS' undeclared (first use in this function)
     return KC_TRNS;
            ^~~~~~~
quantum/keymap_introspection.c: In function 'keymap_layer_count_raw':
quantum/keymap_introspection.c:21:1: error: control reaches end of non-void function [-Werror=return-type]
 }
 ^
quantum/keymap_introspection.c: In function 'keycode_at_keymap_location_raw':
quantum/keymap_introspection.c:38:1: error: control reaches end of non-void function [-Werror=return-type]
 }
 ^
cc1: all warnings being treated as errors
 [ERRORS]
 |
 |
 |
gmake: *** [builddefs/common_rules.mk:373: .build/obj_controllerworks_city42_manna-harbour_miryoku/quantum/keymap_introspection.o] Error 1
```