### PR TITLE
Fix delayed spacebar in TAP layer when using thumbcombos

### DIFF
--- a/users/manna-harbour_miryoku/manna-harbour_miryoku.c
+++ b/users/manna-harbour_miryoku/manna-harbour_miryoku.c
@@ -88,4 +88,15 @@ combo_t key_combos[COMBO_COUNT] = {
   #endif
   COMBO(thumbcombos_fun, KC_APP)
 };
+
+layer_state_t default_layer_state_set_user(layer_state_t state) {
+  if (get_highest_layer(state) == U_TAP) {
+    combo_disable();
+  } else {
+    combo_enable();
+  }
+
+  return state;
+}
+
 #endif


### PR DESCRIPTION
by turning off combos when entering tap layer.

I had this issue where using space in games always felt so delayed on my 34-key Ferris Sweep even though I was using the tap layer and I managed to track it down to the combo handling.

So I added this code to automatically disable and enable combos when entering/leaving the tap layer.
I think this could be useful default behaviour. What do you think?