### PR TITLE
chore: 🤖 Update action "upload-artifact"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           cp *manna-harbour_miryoku* "${{ steps.inputs.outputs.artifact_dir }}"
       - name: Archive artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.inputs.outputs.artifact_build_name }}
           path: ${{ steps.inputs.outputs.artifact_dir }}

--- a/keyboards/beekeeb/piantor/keymaps/manna-harbour_miryoku/config.h
+++ b/keyboards/beekeeb/piantor/keymaps/manna-harbour_miryoku/config.h
@@ -1,0 +1,23 @@
+// Copyright 2022 Manna Harbour
+// https://github.com/manna-harbour/miryoku
+
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#pragma once
+
+#define COMBO_COUNT 1
+
+#define XXX KC_NO
+
+#define LAYOUT_miryoku( \
+      K00,  K01,  K02,  K03,  K04,         K05,  K06,  K07,  K08,  K09, \
+      K10,  K11,  K12,  K13,  K14,         K15,  K16,  K17,  K18,  K19, \
+      K20,  K21,  K22,  K23,  K24,         K25,  K26,  K27,  K28,  K29, \
+      N30,  N31,  K32,  K33,  K34,         K35,  K36,  K37,  N38,  N39 \
+) \
+LAYOUT_split_3x6_3( \
+XXX,  K00,  K01,  K02,  K03,  K04,         K05,  K06,  K07,  K08,  K09,  XXX, \
+XXX,  K10,  K11,  K12,  K13,  K14,         K15,  K16,  K17,  K18,  K19,  XXX, \
+XXX,  K20,  K21,  K22,  K23,  K24,         K25,  K26,  K27,  K28,  K29,  XXX , \
+                  K32,  K33,  K34,         K35,  K36,  K37 \
+)

--- a/keyboards/beekeeb/piantor/keymaps/manna-harbour_miryoku/keymap.c
+++ b/keyboards/beekeeb/piantor/keymaps/manna-harbour_miryoku/keymap.c
@@ -1,0 +1,10 @@
+// Copyright 2019 Manna Harbour
+// https://github.com/manna-harbour/miryoku
+
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with this program. If not, see <http://www.gnu.org/licenses/>.
+#include QMK_KEYBOARD_H
+
+const uint16_t PROGMEM restore_window_size[] = {RWIN(KC_LEFT), RWIN(KC_RIGHT), COMBO_END};
+combo_t key_combos[] = {
+    COMBO(restore_window_size, RWIN(KC_UP)),
+};

--- a/users/manna-harbour_miryoku/custom_config.h
+++ b/users/manna-harbour_miryoku/custom_config.h
@@ -14,7 +14,7 @@
       N30,  N31,  K32,  K33,  K34,         K35,  K36,  K37,  N38,  N39 \
 ) \
 LAYOUT_split_3x6_3( \
-RWIN(RCTL(KC_LEFT)),  K00,  K01,  K02,  K03,  K04,         K05,  K06,  K07,  K08,  K09,  QK_BOOTLOADER, \
+RWIN(RCTL(KC_LEFT)),  K00,  K01,  K02,  K03,  K04,         K05,  K06,  K07,  K08,  K09,  RWIN(RCTL(KC_RIGHT)), \
 RWIN(KC_LEFT),  K10,  K11,  K12,  K13,  K14,         K15,  K16,  K17,  K18,  K19,  RWIN(KC_RIGHT), \
 RSG(KC_LEFT),  K20,  K21,  K22,  K23,  K24,         K25,  K26,  K27,  K28,  K29,  RSG(KC_RIGHT) , \
                   K32,  K33,  K34,         K35,  K36,  K37 \

--- a/users/manna-harbour_miryoku/custom_config.h
+++ b/users/manna-harbour_miryoku/custom_config.h
@@ -1,7 +1,21 @@
-// Copyright 2019 Manna Harbour
+// Copyright 2022 Manna Harbour
 // https://github.com/manna-harbour/miryoku
 
 // This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 2 of the License, or (at your option) any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. You should have received a copy of the GNU General Public License along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
 
+#define XYT KC_ESC
+
+#define MIRYOKU_MAPPING( \
+      K00,  K01,  K02,  K03,  K04,         K05,  K06,  K07,  K08,  K09, \
+      K10,  K11,  K12,  K13,  K14,         K15,  K16,  K17,  K18,  K19, \
+      K20,  K21,  K22,  K23,  K24,         K25,  K26,  K27,  K28,  K29, \
+      N30,  N31,  K32,  K33,  K34,         K35,  K36,  K37,  N38,  N39 \
+) \
+LAYOUT_split_3x6_3( \
+RWIN(RCTL(KC_LEFT)),  K00,  K01,  K02,  K03,  K04,         K05,  K06,  K07,  K08,  K09,  QK_BOOTLOADER, \
+RWIN(KC_LEFT),  K10,  K11,  K12,  K13,  K14,         K15,  K16,  K17,  K18,  K19,  RWIN(KC_RIGHT), \
+RSG(KC_LEFT),  K20,  K21,  K22,  K23,  K24,         K25,  K26,  K27,  K28,  K29,  RSG(KC_RIGHT) , \
+                  K32,  K33,  K34,         K35,  K36,  K37 \
+)

--- a/users/manna-harbour_miryoku/custom_rules.mk
+++ b/users/manna-harbour_miryoku/custom_rules.mk
@@ -2,3 +2,4 @@
 # https://github.com/manna-harbour/miryoku
 MIRYOKU_ALPHAS=QWERTY
 COMBO_ENABLE = yes
+MIRYOKU_NAV = VI

--- a/users/manna-harbour_miryoku/custom_rules.mk
+++ b/users/manna-harbour_miryoku/custom_rules.mk
@@ -1,3 +1,4 @@
 # Copyright 2019 Manna Harbour
 # https://github.com/manna-harbour/miryoku
-
+MIRYOKU_ALPHAS=QWERTY
+COMBO_ENABLE = yes


### PR DESCRIPTION
Builds are failing as `actions/upload-artifact: v3` is no more supported.

`This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/`