### PR TITLE
chore: 🤖 Update upload-artifact to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           cp *manna-harbour_miryoku* "${{ steps.inputs.outputs.artifact_dir }}"
       - name: Archive artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.inputs.outputs.artifact_build_name }}
           path: ${{ steps.inputs.outputs.artifact_dir }}


### PR DESCRIPTION
**Deprecation notice: v3 of the artifact actions.**
Starting _January 30th, 2025, GitHub Actions customers will no longer be able to use v3_ of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact). Customers should update workflows to begin using [v4 of the artifact actions](https://github.blog/2024-02-12-get-started-with-v4-of-github-actions-artifacts/) as soon as possible.